### PR TITLE
Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,50 @@ docker-compose up gossip
 
 ## Sync Protocol
 
+### `sync`
+
+```json
+{
+  "event": "sync",
+  "payload": {
+    "since": "2018-11-24T12:00:00Z"
+  }
+}
+```
+
 ### `sync/channels`
 
 ```json
 {
   "event": "sync/channels",
-  "payload": {
-    "channels": [
-      { } # full channel
-    ]
-  }
+  "payload": [
+    {
+      "action": "create",
+      "payload": { } # full channel
+    },
+    {
+      "action": "update",
+      "payload": { } # full channel
+    },
+    {
+      "action": "delete",
+      "payload": { } # full channel
+    }
+  ]
+}
+```
+
+### `sync/events`
+
+```json
+{
+  "event": "sync/events",
+  "payload": [
+    {
+      "action": "create",
+      "payload": { } # full event
+    }
+  ]
 }
 ```
 
@@ -77,21 +111,15 @@ docker-compose up gossip
 ```json
 {
   "event": "sync/games",
-  "payload": {
-    "channels": [
-      { } # full game
-    ]
-  }
-}
-```
-
-### `sync/deletions`
-
-```json
-{
-  "event": "sync/deletions",
   "payload": [
-    { "type": "game", "id": 1 }
+    {
+      "action": "create",
+      "payload": { } # full game
+    },
+    {
+      "action": "update",
+      "payload": { } # full game
+    }
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ docker-compose up gossip
   "payload": [
     {
       "action": "create",
-      "payload": { } # full channel
+      "payload": { }
     },
     {
       "action": "update",
-      "payload": { } # full channel
+      "payload": { }
     },
     {
       "action": "delete",
-      "payload": { } # full channel
+      "payload": { }
     }
   ]
 }
@@ -100,7 +100,7 @@ docker-compose up gossip
   "payload": [
     {
       "action": "create",
-      "payload": { } # full event
+      "payload": { }
     }
   ]
 }
@@ -114,11 +114,11 @@ docker-compose up gossip
   "payload": [
     {
       "action": "create",
-      "payload": { } # full game
+      "payload": { }
     },
     {
       "action": "update",
-      "payload": { } # full game
+      "payload": { }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -56,3 +56,42 @@ docker-compose up gossip
 ```
 
 [websocket-docs]: https://gossip.haus/docs
+
+## Sync Protocol
+
+### `sync/channels`
+
+```json
+{
+  "event": "sync/channels",
+  "payload": {
+    "channels": [
+      { } # full channel
+    ]
+  }
+}
+```
+
+### `sync/games`
+
+```json
+{
+  "event": "sync/games",
+  "payload": {
+    "channels": [
+      { } # full game
+    ]
+  }
+}
+```
+
+### `sync/deletions`
+
+```json
+{
+  "event": "sync/deletions",
+  "payload": [
+    { "type": "game", "id": 1 }
+  ]
+}
+```

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -180,6 +180,7 @@ pre {
   height: 300px;
 }
 
+
 .players {
   .player {
     display: inline-block;
@@ -188,4 +189,13 @@ pre {
     border: 2px solid $green;
     border-radius: 4px;
   }
+}
+
+
+h3 .actions {
+  display: inline-block;
+}
+
+h3 a {
+  text-decoration: none !important;
 }

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -2,7 +2,7 @@ $green: #00bb00;
 $dark-green: #00CC00;
 
 main {
-  padding-top: 3em;
+  padding-top: 1em;
 }
 
 h3 a,

--- a/lib/gossip/events.ex
+++ b/lib/gossip/events.ex
@@ -1,0 +1,87 @@
+defmodule Gossip.Events do
+  @moduledoc """
+  Contect for managing a game's events
+  """
+
+  import Ecto.Query
+
+  alias Gossip.Events.Event
+  alias Gossip.Repo
+
+  @doc """
+  New changeset for an event
+  """
+  def new(game) do
+    game
+    |> Ecto.build_assoc(:events)
+    |> Event.changeset(%{})
+  end
+
+  @doc """
+  Edit changeset for an event
+  """
+  def edit(event) do
+    event
+    |> Event.changeset(%{})
+  end
+
+  @doc """
+  Get all events for a game
+  """
+  def for(game) do
+    Event
+    |> where([e], e.game_id == ^game.id)
+    |> order_by([e], desc: e.start_date)
+    |> Repo.all()
+  end
+
+  @doc """
+  Get an event for a user
+
+  Scoped to the user
+  """
+  def get(user, id) do
+    case Repo.get(Event, id) do
+      nil ->
+        {:error, :not_found}
+
+      event ->
+        event = Repo.preload(event, [:game])
+
+        case event.game.user_id == user.id do
+          true ->
+            {:ok, event}
+
+          false ->
+            {:error, :not_found}
+        end
+    end
+  end
+
+  @doc """
+  Create a new event for a game
+  """
+  def create(game, params) do
+    game
+    |> Ecto.build_assoc(:events)
+    |> Event.changeset(params)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Update a game for an event
+  """
+  def update(event, params) do
+    event
+    |> Event.changeset(params)
+    |> Repo.update()
+  end
+
+  @doc """
+  Delete an event
+  """
+  def delete(event) do
+    event
+    |> Repo.delete()
+  end
+end

--- a/lib/gossip/events.ex
+++ b/lib/gossip/events.ex
@@ -59,29 +59,86 @@ defmodule Gossip.Events do
   end
 
   @doc """
+  Get an event and preload it
+  """
+  def get(id) do
+    case Repo.get(Event, id) do
+      nil ->
+        {:error, :not_found}
+
+      event ->
+        {:ok, Repo.preload(event, [:game])}
+    end
+  end
+
+  @doc """
   Create a new event for a game
   """
   def create(game, params) do
-    game
-    |> Ecto.build_assoc(:events)
-    |> Event.changeset(params)
-    |> Repo.insert()
+    changeset =
+      game
+      |> Ecto.build_assoc(:events)
+      |> Event.changeset(params)
+
+    case Repo.insert(changeset) do
+      {:ok, event} ->
+        broadcast_event_create(event.id)
+        {:ok, event}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   @doc """
   Update a game for an event
   """
   def update(event, params) do
-    event
-    |> Event.changeset(params)
-    |> Repo.update()
+    changeset = event |> Event.changeset(params)
+
+    case Repo.update(changeset) do
+      {:ok, event} ->
+        broadcast_event_update(event.id)
+        {:ok, event}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   @doc """
   Delete an event
   """
   def delete(event) do
-    event
-    |> Repo.delete()
+    case Repo.delete(event) do
+      {:ok, event} ->
+        broadcast_event_delete(event)
+        {:ok, event}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  defp broadcast_event_create(event_id) do
+    with {:ok, event} <- get(event_id) do
+      Web.Endpoint.broadcast("system:backbone", "events/new", event)
+    else
+      _ ->
+        :ok
+    end
+  end
+
+  defp broadcast_event_update(event_id) do
+    with {:ok, event} <- get(event_id) do
+      Web.Endpoint.broadcast("system:backbone", "events/edit", event)
+    else
+      _ ->
+        :ok
+    end
+  end
+
+  defp broadcast_event_delete(event) do
+    Web.Endpoint.broadcast("system:backbone", "events/delete", event)
   end
 end

--- a/lib/gossip/events/event.ex
+++ b/lib/gossip/events/event.ex
@@ -32,7 +32,7 @@ defmodule Gossip.Events.Event do
   defp validate_start_before_end(changeset) do
     with start_date when start_date != nil <- get_field(changeset, :start_date),
          end_date when end_date != nil <- get_field(changeset, :end_date) do
-      case Timex.before?(start_date, end_date) do
+      case Timex.before?(start_date, end_date) || start_date == end_date do
         true ->
           changeset
 

--- a/lib/gossip/events/event.ex
+++ b/lib/gossip/events/event.ex
@@ -1,0 +1,47 @@
+defmodule Gossip.Events.Event do
+  @moduledoc """
+  Event Schema
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Gossip.Games.Game
+
+  @type t :: %__MODULE__{}
+
+  schema "events" do
+    field(:title, :string)
+    field(:description, :string)
+    field(:start_date, :date)
+    field(:end_date, :date)
+
+    belongs_to(:game, Game)
+
+    timestamps()
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [:title, :description, :start_date, :end_date])
+    |> validate_required([:title, :start_date, :end_date])
+    |> validate_start_before_end()
+  end
+
+  defp validate_start_before_end(changeset) do
+    with start_date when start_date != nil <- get_field(changeset, :start_date),
+         end_date when end_date != nil <- get_field(changeset, :end_date) do
+      case Timex.before?(start_date, end_date) do
+        true ->
+          changeset
+
+        false ->
+          add_error(changeset, :end_date, "must come after the start date")
+      end
+    else
+      _ ->
+        changeset
+    end
+  end
+end

--- a/lib/gossip/games.ex
+++ b/lib/gossip/games.ex
@@ -9,6 +9,7 @@ defmodule Gossip.Games do
   alias Gossip.Games.RedirectURI
   alias Gossip.Repo
   alias Gossip.UserAgents
+  alias Gossip.Versions
 
   import Ecto.Query
 
@@ -359,8 +360,9 @@ defmodule Gossip.Games do
   end
 
   defp broadcast_game_create(game_id) do
-    with {:ok, game} <- get(game_id) do
-      Web.Endpoint.broadcast("system:backbone", "games/new", game)
+    with {:ok, game} <- get(game_id),
+         {:ok, version} <- Versions.log("create", game) do
+      Web.Endpoint.broadcast("system:backbone", "games/new", version)
     else
       _ ->
         :ok
@@ -368,8 +370,9 @@ defmodule Gossip.Games do
   end
 
   defp broadcast_game_update(game_id) do
-    with {:ok, game} <- get(game_id) do
-      Web.Endpoint.broadcast("system:backbone", "games/edit", game)
+    with {:ok, game} <- get(game_id),
+         {:ok, version} <- Versions.log("update", game) do
+      Web.Endpoint.broadcast("system:backbone", "games/edit", version)
     else
       _ ->
         :ok

--- a/lib/gossip/games/game.ex
+++ b/lib/gossip/games/game.ex
@@ -8,6 +8,7 @@ defmodule Gossip.Games.Game do
   import Ecto.Changeset
 
   alias Gossip.Accounts.User
+  alias Gossip.Events.Event
   alias Gossip.Games
   alias Gossip.Games.Connection
   alias Gossip.Games.RedirectURI
@@ -31,6 +32,7 @@ defmodule Gossip.Games.Game do
     belongs_to(:user, User)
 
     has_many(:connections, Connection)
+    has_many(:events, Event)
     has_many(:redirect_uris, RedirectURI)
 
     timestamps()

--- a/lib/gossip/versions.ex
+++ b/lib/gossip/versions.ex
@@ -42,7 +42,7 @@ defmodule Gossip.Versions do
   def for(schema, since) do
     Version
     |> where([v], v.schema == ^schema)
-    |> where([v], v.logged_at >= ^since)
+    |> where([v], v.logged_at > ^since)
     |> order_by([v], asc: v.logged_at)
     |> Repo.all()
   end

--- a/lib/gossip/versions.ex
+++ b/lib/gossip/versions.ex
@@ -1,0 +1,110 @@
+defmodule Gossip.Versions do
+  @moduledoc """
+  Context around tracking schema versions for sync
+  """
+
+  import Ecto.Query
+
+  alias Gossip.Channels.Channel
+  alias Gossip.Events.Event
+  alias Gossip.Games.Game
+  alias Gossip.Repo
+  alias Gossip.UserAgents
+  alias Gossip.Versions.Version
+  alias Web.ConnectionView
+
+  @doc """
+  Log a new action on a supported schema
+
+  Actions can be one of: create, update, delete
+  """
+  def log(action, schema, logged_at \\ Timex.now()) do
+    attributes = %{
+      action: action,
+      schema: schema_for(schema),
+      schema_id: schema.id,
+      payload: payload_for(schema),
+      logged_at: logged_at,
+    }
+
+    %Version{}
+    |> Version.changeset(attributes)
+    |> Repo.insert()
+  end
+
+  def for(schema, nil) do
+    Version
+    |> where([v], v.schema == ^schema)
+    |> Repo.all()
+  end
+
+  def for(schema, since) do
+    Version
+    |> where([v], v.schema == ^schema)
+    |> where([v], v.logged_at >= ^since)
+    |> Repo.all()
+  end
+
+  defp schema_for(%Channel{}), do: "channels"
+  defp schema_for(%Event{}), do: "events"
+  defp schema_for(%Game{}), do: "games"
+
+  defp payload_for(channel = %Channel{}) do
+    Map.take(channel, Channel.__schema__(:fields))
+  end
+
+  defp payload_for(event = %Event{}) do
+    Map.take(event, Event.__schema__(:fields))
+  end
+
+  defp payload_for(game = %Game{}) do
+    %{
+      id: game.id,
+      game: game.short_name,
+      display_name: game.name,
+      display: game.display,
+      description: game.description,
+      homepage_url: game.homepage_url,
+      user_agent: game.user_agent,
+      user_agent_url: user_agent_repo_url(game.user_agent),
+      connections: format_connections(game.connections),
+      redirect_uris: format_redirect_uris(game.redirect_uris),
+      allow_character_registration: game.allow_character_registration,
+      client_id: game.client_id,
+      client_secret: game.client_secret,
+    }
+  end
+
+  defp format_connections(connections) do
+    connections
+    |> Enum.map(fn connection ->
+      ConnectionView.render("show.json", %{connection: connection})
+    end)
+  end
+
+  defp format_redirect_uris(redirect_uris) do
+    Enum.map(redirect_uris, &(&1.uri))
+  end
+
+  defp user_agent_repo_url(nil), do: nil
+
+  defp user_agent_repo_url(user_agent) do
+    with {:ok, user_agent} <- UserAgents.get_user_agent(user_agent),
+         {:ok, user_agent} <- check_if_repo_url(user_agent) do
+      user_agent.repo_url
+    else
+      _ ->
+        nil
+    end
+  end
+
+  defp check_if_repo_url(user_agent) do
+    case user_agent.repo_url do
+      nil ->
+        {:error, :no_repo_url, user_agent}
+
+      _ ->
+        {:ok, user_agent}
+    end
+  end
+end

--- a/lib/gossip/versions.ex
+++ b/lib/gossip/versions.ex
@@ -35,6 +35,7 @@ defmodule Gossip.Versions do
   def for(schema, nil) do
     Version
     |> where([v], v.schema == ^schema)
+    |> order_by([v], asc: v.logged_at)
     |> Repo.all()
   end
 
@@ -42,6 +43,7 @@ defmodule Gossip.Versions do
     Version
     |> where([v], v.schema == ^schema)
     |> where([v], v.logged_at >= ^since)
+    |> order_by([v], asc: v.logged_at)
     |> Repo.all()
   end
 

--- a/lib/gossip/versions/version.ex
+++ b/lib/gossip/versions/version.ex
@@ -1,0 +1,30 @@
+defmodule Gossip.Versions.Version do
+  @moduledoc """
+  Game Schema
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @actions ["create", "update", "delete"]
+  @schemas ["channels", "games", "events"]
+
+  @type t :: %__MODULE__{}
+
+  schema "versions" do
+    field(:action, :string)
+    field(:schema, :string)
+    field(:schema_id, :integer)
+    field(:payload, :map)
+    field(:logged_at, :utc_datetime)
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [:action, :schema, :schema_id, :payload, :logged_at])
+    |> validate_required([:action, :schema, :schema_id, :payload, :logged_at])
+    |> validate_inclusion(:action, @actions)
+    |> validate_inclusion(:schema, @schemas)
+  end
+end

--- a/lib/socket/backbone.ex
+++ b/lib/socket/backbone.ex
@@ -150,7 +150,7 @@ defmodule Socket.Backbone do
     token()
     |> assign(:type, "event")
     |> assign(:id, event.id)
-    |> event("sync/delete")
+    |> event("sync/deletions")
     |> relay()
   end
 
@@ -172,11 +172,11 @@ defmodule Socket.Backbone do
       }
     end
 
-    def event("sync/delete", %{type: type, id: id}) do
+    def event("sync/deletions", %{type: type, id: id}) do
       %{
-        event: "sync/delete",
+        event: "sync/deletions",
         ref: UUID.uuid4(),
-        payload: %{type: type, id: id},
+        payload: [%{type: type, id: id}],
       }
     end
 

--- a/lib/socket/backbone.ex
+++ b/lib/socket/backbone.ex
@@ -75,6 +75,7 @@ defmodule Socket.Backbone do
     since = Map.get(payload, "since")
     sync_channels(since)
     sync_games(since)
+    sync_events(since)
     {:ok, state}
   end
 
@@ -144,6 +145,16 @@ defmodule Socket.Backbone do
     |> assign(:versions, versions)
     |> event("sync/games")
     |> relay()
+  end
+
+  @doc """
+  Send batches of `sync/events` events to newly connected sockets
+  """
+  def sync_events(since \\ nil) do
+    "events"
+    |> Versions.for(since)
+    |> Enum.chunk_every(10)
+    |> Enum.each(&broadcast_events/1)
   end
 
   defp broadcast_events(versions) do

--- a/lib/web/controllers/event_controller.ex
+++ b/lib/web/controllers/event_controller.ex
@@ -48,9 +48,11 @@ defmodule Web.EventController do
   def edit(conn, %{"id" => id}) do
     %{current_user: user} = conn.assigns
 
-    with {:ok, event} = Events.get(user, id) do
+    with {:ok, event} = Events.get(user, id),
+         {:ok, game} = Games.get(user, event.game_id) do
       conn
       |> assign(:event, event)
+      |> assign(:game, game)
       |> assign(:changeset, Events.edit(event))
       |> render("edit.html")
     end
@@ -65,9 +67,11 @@ defmodule Web.EventController do
     else
       {:error, changeset} ->
         {:ok, event} = Events.get(user, id)
+        {:ok, game} = Games.get(user, event.game_id)
 
         conn
         |> assign(:event, event)
+        |> assign(:game, game)
         |> assign(:changeset, changeset)
         |> render("edit.html")
     end

--- a/lib/web/controllers/event_controller.ex
+++ b/lib/web/controllers/event_controller.ex
@@ -1,0 +1,84 @@
+defmodule Web.EventController do
+  use Web, :controller
+
+  alias Gossip.Games
+  alias Gossip.Events
+
+  plug Web.Plugs.VerifyUser
+
+  def index(conn, %{"game_id" => game_id}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, game} <- Games.get(user, game_id) do
+      conn
+      |> assign(:game, game)
+      |> assign(:events, Events.for(game))
+      |> render("index.html")
+    end
+  end
+
+  def new(conn, %{"game_id" => game_id}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, game} <- Games.get(user, game_id) do
+      conn
+      |> assign(:game, game)
+      |> assign(:changeset, Events.new(game))
+      |> render("new.html")
+    end
+  end
+
+  def create(conn, %{"game_id" => game_id, "event" => params}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, game} <- Games.get(user, game_id),
+         {:ok, _event} <- Events.create(game, params) do
+      redirect(conn, to: game_event_path(conn, :index, game.id))
+    else
+      {:error, changeset} ->
+        {:ok, game} = Games.get(user, game_id)
+
+        conn
+        |> assign(:game, game)
+        |> assign(:changeset, changeset)
+        |> render("new.html")
+    end
+  end
+
+  def edit(conn, %{"id" => id}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, event} = Events.get(user, id) do
+      conn
+      |> assign(:event, event)
+      |> assign(:changeset, Events.edit(event))
+      |> render("edit.html")
+    end
+  end
+
+  def update(conn, %{"id" => id, "event" => params}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, event} <- Events.get(user, id),
+         {:ok, event} <- Events.update(event, params) do
+      redirect(conn, to: game_event_path(conn, :index, event.game_id))
+    else
+      {:error, changeset} ->
+        {:ok, event} = Events.get(user, id)
+
+        conn
+        |> assign(:event, event)
+        |> assign(:changeset, changeset)
+        |> render("edit.html")
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, event} <- Events.get(user, id),
+         {:ok, event} <- Events.delete(event) do
+      redirect(conn, to: game_event_path(conn, :index, event.game_id))
+    end
+  end
+end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -27,10 +27,14 @@ defmodule Web.Router do
 
     get("/docs", PageController, :docs)
 
+    resources("/events", EventController, only: [:edit, :update, :delete])
+
     resources("/games/mine", UserGameController, only: [:index, :create])
 
     resources("/games", GameController, only: [:index, :show, :edit, :update]) do
       resources("/connections", ConnectionController, only: [:create])
+
+      resources("/events", EventController, only: [:index, :new, :create])
 
       resources("/redirect-uris", RedirectURIController, only: [:create])
 

--- a/lib/web/socket/router.ex
+++ b/lib/web/socket/router.ex
@@ -47,6 +47,13 @@ defmodule Web.Socket.Router do
     |> Response.respond_to(state)
   end
 
+  def receive(state = %{status: "active"}, event = %{"event" => "sync"}) do
+    state
+    |> Backbone.sync(event)
+    |> Response.wrap(event, "sync")
+    |> Response.respond_to(state)
+  end
+
   def receive(state = %{status: "inactive"}, frame) do
     Logger.warn("Getting an unknown frame unauthenticated - #{inspect(frame)}")
     {:ok, %{status: "failure", error: "unauthenticated"}, state}

--- a/lib/web/templates/chat/index.html.eex
+++ b/lib/web/templates/chat/index.html.eex
@@ -1,3 +1,10 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item active">Chat</li>
+  </ol>
+</nav>
+
 <div class="card-columns">
   <%= Enum.map(Channels.all(), fn channel -> %>
     <div class="card" style="width: 18rem;">

--- a/lib/web/templates/chat/show.html.eex
+++ b/lib/web/templates/chat/show.html.eex
@@ -1,3 +1,11 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link("Chat", to: chat_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item active"><%= @channel.name %></li>
+  </ol>
+</nav>
+
 <h2><%= @channel.name %></h2>
 
 <div id="channel-<%= @channel.name %>" data-channel="<%= @channel.name %>" class="terminal channel">

--- a/lib/web/templates/event/_form.html.eex
+++ b/lib/web/templates/event/_form.html.eex
@@ -1,0 +1,27 @@
+<%= form_for(@changeset, @url, fn f -> %>
+  <div class="form-group">
+    <%= label(f, :title) %>
+    <%= text_input(f, :title, class: "form-control") %>
+    <%= error_tag(f, :title) %>
+  </div>
+
+  <div class="form-group">
+    <%= label(f, :description) %>
+    <%= textarea(f, :description, class: "form-control", rows: 5) %>
+    <%= error_tag(f, :description) %>
+  </div>
+
+  <div class="form-group">
+    <%= label(f, :start_date) %>
+    <%= text_input(f, :start_date, class: "form-control") %>
+    <%= error_tag(f, :start_date) %>
+  </div>
+
+  <div class="form-group">
+    <%= label(f, :end_date) %>
+    <%= text_input(f, :end_date, class: "form-control") %>
+    <%= error_tag(f, :end_date) %>
+  </div>
+
+  <%= submit(@submit, class: "btn btn-secondary") %>
+<% end) %>

--- a/lib/web/templates/event/edit.html.eex
+++ b/lib/web/templates/event/edit.html.eex
@@ -1,0 +1,6 @@
+<div class="row">
+  <div class="col-md-6 offset-md-3">
+    <h3>Edit <%= @event.title %></h3>
+    <%= render("_form.html", changeset: @changeset, url: event_path(@conn, :update, @event.id), submit: "Update Event") %>
+  </div>
+</div>

--- a/lib/web/templates/event/edit.html.eex
+++ b/lib/web/templates/event/edit.html.eex
@@ -1,3 +1,13 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link("Your Games", to: user_game_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link(@game.name, to: game_path(@conn, :show, @game.id)) %></li>
+    <li class="breadcrumb-item"><%= link("Events", to: game_event_path(@conn, :index, @game.id)) %></li>
+    <li class="breadcrumb-item active"><%= @event.title %> Edit</li>
+  </ol>
+</nav>
+
 <div class="row">
   <div class="col-md-6 offset-md-3">
     <h3>Edit <%= @event.title %></h3>

--- a/lib/web/templates/event/index.html.eex
+++ b/lib/web/templates/event/index.html.eex
@@ -28,7 +28,11 @@
   <%= Enum.map(@events, fn event -> %>
     <tr>
       <td><%= event.title %></td>
-      <td><%= text_to_html(event.description) %></td>
+      <td>
+        <%= if event.description do %>
+          <%= text_to_html(event.description) %>
+        <% end %>
+      </td>
       <td><%= event.start_date %> to <%= event.end_date %></td>
       <td>
         <%= link("Edit", to: event_path(@conn, :edit, event.id), class: "btn btn-light") %>

--- a/lib/web/templates/event/index.html.eex
+++ b/lib/web/templates/event/index.html.eex
@@ -1,0 +1,30 @@
+<h3>
+  <%= @game.name %> Events
+
+  <div class="actions">
+    <%= link("New Event", to: game_event_path(@conn, :new, @game.id), class: "btn btn-primary") %>
+  </div>
+</h3>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Start Date</th>
+      <th>End Date</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+
+  <%= Enum.map(@events, fn event -> %>
+    <tr>
+      <td><%= event.title %></td>
+      <td><%= event.start_date %></td>
+      <td><%= event.end_date %></td>
+      <td>
+        <%= link("Edit", to: event_path(@conn, :edit, event.id), class: "btn btn-light") %>
+        <%= link("Delete", to: event_path(@conn, :delete, event.id), method: :delete, class: "btn btn-danger") %>
+      </td>
+    </tr>
+  <% end) %>
+</table>

--- a/lib/web/templates/event/index.html.eex
+++ b/lib/web/templates/event/index.html.eex
@@ -19,8 +19,8 @@
   <thead>
     <tr>
       <th>Title</th>
-      <th>Start Date</th>
-      <th>End Date</th>
+      <th>Description</th>
+      <th>Dates</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -28,8 +28,8 @@
   <%= Enum.map(@events, fn event -> %>
     <tr>
       <td><%= event.title %></td>
-      <td><%= event.start_date %></td>
-      <td><%= event.end_date %></td>
+      <td><%= text_to_html(event.description) %></td>
+      <td><%= event.start_date %> to <%= event.end_date %></td>
       <td>
         <%= link("Edit", to: event_path(@conn, :edit, event.id), class: "btn btn-light") %>
         <%= link("Delete", to: event_path(@conn, :delete, event.id), method: :delete, class: "btn btn-danger") %>

--- a/lib/web/templates/event/index.html.eex
+++ b/lib/web/templates/event/index.html.eex
@@ -1,3 +1,12 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link("Your Games", to: user_game_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link(@game.name, to: game_path(@conn, :show, @game.id)) %></li>
+    <li class="breadcrumb-item active">Events</li>
+  </ol>
+</nav>
+
 <h3>
   <%= @game.name %> Events
 

--- a/lib/web/templates/event/new.html.eex
+++ b/lib/web/templates/event/new.html.eex
@@ -1,3 +1,13 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link("Your Games", to: user_game_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link(@game.name, to: game_path(@conn, :show, @game.id)) %></li>
+    <li class="breadcrumb-item"><%= link("Events", to: game_event_path(@conn, :index, @game.id)) %></li>
+    <li class="breadcrumb-item active">New</li>
+  </ol>
+</nav>
+
 <div class="row">
   <div class="col-md-6 offset-md-3">
     <h3>Create a new Event</h3>

--- a/lib/web/templates/event/new.html.eex
+++ b/lib/web/templates/event/new.html.eex
@@ -1,0 +1,6 @@
+<div class="row">
+  <div class="col-md-6 offset-md-3">
+    <h3>Create a new Event</h3>
+    <%= render("_form.html", changeset: @changeset, url: game_event_path(@conn, :create, @game.id), submit: "Create Event") %>
+  </div>
+</div>

--- a/lib/web/templates/game/edit.html.eex
+++ b/lib/web/templates/game/edit.html.eex
@@ -1,3 +1,12 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link("Your Games", to: user_game_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link(@game.name, to: game_path(@conn, :show, @game.id)) %></li>
+    <li class="breadcrumb-item active">Edit</li>
+  </ol>
+</nav>
+
 <div class="row">
   <div class="col-md-6 offset-md-3">
     <h3>Edit <%= @game.name %></h3>

--- a/lib/web/templates/game/edit.html.eex
+++ b/lib/web/templates/game/edit.html.eex
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-6 offset-md-3">
-    <h3>Create a new Game</h3>
+    <h3>Edit <%= @game.name %></h3>
 
     <%= form_for(@changeset, game_path(@conn, :update, @game.id), fn f -> %>
       <div class="form-group">

--- a/lib/web/templates/game/index.html.eex
+++ b/lib/web/templates/game/index.html.eex
@@ -1,3 +1,10 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item active">Games</li>
+  </ol>
+</nav>
+
 <h2>Connected Games</h2>
 
 <%= if Enum.empty?(@games) do %>

--- a/lib/web/templates/game/show.html.eex
+++ b/lib/web/templates/game/show.html.eex
@@ -1,14 +1,22 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item"><%= link("Your Games", to: user_game_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item active"><%= @game.name %></li>
+  </ol>
+</nav>
+
+<h3 class="game-title">
+  <%= @game.name %> Settings
+
+  <div class="actions">
+    <%= link("Edit", to: game_path(@conn, :edit, @game.id), class: "btn btn-light") %>
+    <%= link("View Events", to: game_event_path(@conn, :index, @game.id), class: "btn btn-light") %>
+  </div>
+</h3>
+
 <div class="row mt-3">
   <div class="col-md-6">
-    <h3 class="game-title">
-      <%= @game.name %> Settings
-      <%= link("Edit", to: game_path(@conn, :edit, @game.id), class: "btn btn-default") %>
-    </h3>
-
-    <div class="actions">
-      <%= link("View Events", to: game_event_path(@conn, :index, @game.id)) %>
-    </div>
-
     <dl>
       <dd>Short Name</dd>
       <dl><%= @game.short_name %></dl>

--- a/lib/web/templates/game/show.html.eex
+++ b/lib/web/templates/game/show.html.eex
@@ -5,6 +5,10 @@
       <%= link("Edit", to: game_path(@conn, :edit, @game.id), class: "btn btn-default") %>
     </h3>
 
+    <div class="actions">
+      <%= link("View Events", to: game_event_path(@conn, :index, @game.id)) %>
+    </div>
+
     <dl>
       <dd>Short Name</dd>
       <dl><%= @game.short_name %></dl>

--- a/lib/web/templates/page/conduct.html.eex
+++ b/lib/web/templates/page/conduct.html.eex
@@ -1,0 +1,8 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item active">Code of Conduct</li>
+  </ol>
+</nav>
+
+<%= render("_conduct.html") %>

--- a/lib/web/templates/page/docs.html.eex
+++ b/lib/web/templates/page/docs.html.eex
@@ -1,3 +1,10 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item active">Docs</li>
+  </ol>
+</nav>
+
 <div class="row">
   <div class="col-md-4">
     <h5>Table of Contents</h5>

--- a/lib/web/templates/page/media.html.eex
+++ b/lib/web/templates/page/media.html.eex
@@ -1,3 +1,10 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item active">Media</li>
+  </ol>
+</nav>
+
 <h2>Gossip Media</h2>
 
 <h4>Logo</h4>

--- a/lib/web/templates/user_game/index.html.eex
+++ b/lib/web/templates/user_game/index.html.eex
@@ -1,3 +1,10 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><%= link("Home", to: page_path(@conn, :index)) %></li>
+    <li class="breadcrumb-item active">Your Games</li>
+  </ol>
+</nav>
+
 <div class="row">
   <div class="col-md-3">
     <h3>Create a new Game</h3>
@@ -41,8 +48,8 @@
             <td><%= game.name %></td>
             <td><%= game.short_name %></td>
             <td>
-              <%= link("View", to: game_path(@conn, :show, game.id), class: "btn btn-default") %>
-              <%= link("Edit", to: game_path(@conn, :edit, game.id), class: "btn btn-default") %>
+              <%= link("View", to: game_path(@conn, :show, game.id), class: "btn btn-light") %>
+              <%= link("Edit", to: game_path(@conn, :edit, game.id), class: "btn btn-light") %>
             </td>
           </tr>
         <% end) %>

--- a/lib/web/views/event_view.ex
+++ b/lib/web/views/event_view.ex
@@ -1,0 +1,3 @@
+defmodule Web.EventView do
+  use Web, :view
+end

--- a/lib/web/views/page_view.ex
+++ b/lib/web/views/page_view.ex
@@ -6,7 +6,7 @@ defmodule Web.PageView do
   alias Gossip.Channels
   alias Web.DocView
 
-  def render("conduct.html", _assigns) do
+  def render("_conduct.html", _assigns) do
     :gossip
     |> :code.priv_dir()
     |> Path.join("pages/CODE_OF_CONDUCT.md")

--- a/priv/repo/migrations/20181122035954_create_events.exs
+++ b/priv/repo/migrations/20181122035954_create_events.exs
@@ -1,0 +1,15 @@
+defmodule Gossip.Repo.Migrations.CreateEvents do
+  use Ecto.Migration
+
+  def change do
+    create table(:events) do
+      add(:game_id, references(:games), null: false)
+      add(:title, :text, null: false)
+      add(:description, :text)
+      add(:start_date, :date)
+      add(:end_date, :date)
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20181125000013_create_sync_events.exs
+++ b/priv/repo/migrations/20181125000013_create_sync_events.exs
@@ -1,0 +1,15 @@
+defmodule Gossip.Repo.Migrations.CreateSyncEvents do
+  use Ecto.Migration
+
+  def change do
+    create table(:versions) do
+      add(:action, :string, null: false)
+      add(:schema, :string, null: false)
+      add(:schema_id, :integer, null: false)
+      add(:payload, :jsonb, null: false)
+      add(:logged_at, :utc_datetime)
+    end
+
+    create index(:versions, [:schema, :logged_at])
+  end
+end

--- a/test/gossip/events_test.exs
+++ b/test/gossip/events_test.exs
@@ -1,0 +1,63 @@
+defmodule Gossip.EventsTest do
+  use Gossip.DataCase
+
+  alias Gossip.Events
+
+  describe "create a new event" do
+    test "successful" do
+      game = create_game(create_user())
+
+      {:ok, event} = Events.create(game, %{
+        title: "Adventuring",
+        start_date: "2018-11-21",
+        end_date: "2018-11-23"
+      })
+
+      assert event.title == "Adventuring"
+      assert event.start_date == ~D[2018-11-21]
+      assert event.end_date == ~D[2018-11-23]
+    end
+
+    test "failure" do
+      game = create_game(create_user())
+
+      {:error, _changeset} = Events.create(game, %{
+        title: "Adventuring",
+        start_date: "2018-11-21",
+        end_date: "2018-11-20"
+      })
+    end
+  end
+
+  describe "updating an event" do
+    test "successful" do
+      game = create_game(create_user())
+
+      {:ok, event} = Events.create(game, %{
+        title: "Adventuring",
+        start_date: "2018-11-21",
+        end_date: "2018-11-23"
+      })
+
+      {:ok, event} = Events.update(event, %{
+        end_date: "2018-11-24"
+      })
+
+      assert event.end_date == ~D[2018-11-24]
+    end
+  end
+
+  describe "deleting an event" do
+    test "successful" do
+      game = create_game(create_user())
+
+      {:ok, event} = Events.create(game, %{
+        title: "Adventuring",
+        start_date: "2018-11-21",
+        end_date: "2018-11-23"
+      })
+
+      {:ok, _event} = Events.delete(event)
+    end
+  end
+end

--- a/test/gossip/versions_test.exs
+++ b/test/gossip/versions_test.exs
@@ -1,0 +1,32 @@
+defmodule Gossip.VersionsTest do
+  use Gossip.DataCase
+
+  alias Gossip.Games
+  alias Gossip.Versions
+
+  describe "log a new action" do
+    test "create action" do
+      game = create_game(create_user())
+      {:ok, game} = Games.get(game.id)
+
+      {:ok, version} = Versions.log("create", game)
+
+      assert version.action == "create"
+      assert version.schema == "games"
+      assert version.schema_id == game.id
+      assert version.payload.id == game.id
+    end
+
+    test "update action" do
+      game = create_game(create_user())
+      {:ok, game} = Games.get(game.id)
+
+      {:ok, version} = Versions.log("update", game)
+
+      assert version.action == "update"
+      assert version.schema == "games"
+      assert version.schema_id == game.id
+      assert version.payload.id == game.id
+    end
+  end
+end

--- a/test/socket/backbone_test.exs
+++ b/test/socket/backbone_test.exs
@@ -56,7 +56,7 @@ defmodule Socket.BackboneTest do
 
       Backbone.process_event(state, message)
 
-      assert_receive {:broadcast, %{event: "sync/delete"}}
+      assert_receive {:broadcast, %{event: "sync/deletions"}}
     end
 
     test "broadcasts new games", %{state: state} do

--- a/test/socket/backbone_test.exs
+++ b/test/socket/backbone_test.exs
@@ -1,9 +1,9 @@
 defmodule Socket.BackboneTest do
   use Gossip.DataCase
 
-  alias Gossip.Channels.Channel
-  alias Gossip.Events.Event
-  alias Gossip.Games.Game
+  alias Gossip.Games
+  alias Gossip.Versions
+  alias Gossip.Versions.Version
   alias Socket.Backbone
 
   describe "backbone processing" do
@@ -15,7 +15,9 @@ defmodule Socket.BackboneTest do
     end
 
     test "new channel subscribes to that new channel", %{state: state} do
-      message = %Phoenix.Socket.Broadcast{topic: "system:backbone", event: "channels/new", payload: %Channel{name: "newChannel"}}
+      payload = %Version{action: "create", payload: %{name: "newChannel"}}
+
+      message = %Phoenix.Socket.Broadcast{topic: "system:backbone", event: "channels/new", payload: payload}
       Backbone.process_event(state, message)
 
       Web.Endpoint.broadcast("channels:newChannel", "channels/broadcast", %{message: "hi"})
@@ -27,7 +29,7 @@ defmodule Socket.BackboneTest do
       message = %Phoenix.Socket.Broadcast{
         topic: "system:backbone",
         event: "events/new",
-        payload: %Event{title: "A Holiday"}
+        payload: %Version{action: "create", payload: %{title: "A Holiday"}}
       }
 
       Backbone.process_event(state, message)
@@ -39,7 +41,7 @@ defmodule Socket.BackboneTest do
       message = %Phoenix.Socket.Broadcast{
         topic: "system:backbone",
         event: "events/edit",
-        payload: %Event{title: "A Holiday"}
+        payload: %Version{action: "update", payload: %{title: "A Holiday"}}
       }
 
       Backbone.process_event(state, message)
@@ -51,19 +53,19 @@ defmodule Socket.BackboneTest do
       message = %Phoenix.Socket.Broadcast{
         topic: "system:backbone",
         event: "events/delete",
-        payload: %Event{id: 1, title: "A Holiday"}
+        payload: %Version{action: "delete", payload: %{id: 2, title: "A Holiday"}}
       }
 
       Backbone.process_event(state, message)
 
-      assert_receive {:broadcast, %{event: "sync/deletions"}}
+      assert_receive {:broadcast, %{event: "sync/events"}}
     end
 
     test "broadcasts new games", %{state: state} do
       message = %Phoenix.Socket.Broadcast{
         topic: "system:backbone",
         event: "games/new",
-        payload: %Game{name: "game", connections: [], redirect_uris: []}
+        payload: %Version{action: "create", payload: %{name: "game", connections: [], redirect_uris: []}}
       }
 
       Backbone.process_event(state, message)
@@ -75,7 +77,7 @@ defmodule Socket.BackboneTest do
       message = %Phoenix.Socket.Broadcast{
         topic: "system:backbone",
         event: "games/edit",
-        payload: %Game{name: "game", connections: [], redirect_uris: []}
+        payload: %Version{action: "update", payload: %{name: "game", connections: [], redirect_uris: []}}
       }
 
       Backbone.process_event(state, message)
@@ -103,6 +105,21 @@ defmodule Socket.BackboneTest do
       assert_receive {:broadcast, %{event: "sync/channels"}}
       assert_receive {:broadcast, %{event: "sync/channels"}}
     end
+
+    test "limits based on a timestamp if present" do
+      now = Timex.now()
+
+      channel = create_channel(%{name: "gossip"})
+      Enum.each(1..12, fn i ->
+        Versions.log("update", channel, now |> Timex.shift(minutes: -1 * i))
+      end)
+
+      five_minutes_ago = Timex.now() |> Timex.shift(minutes: -5)
+      Backbone.sync_channels(five_minutes_ago)
+
+      assert_receive {:broadcast, %{event: "sync/channels"}}
+      refute_receive {:broadcast, %{event: "sync/channels"}}
+    end
   end
 
   describe "syncing games" do
@@ -128,6 +145,24 @@ defmodule Socket.BackboneTest do
 
       assert_receive {:broadcast, %{event: "sync/games"}}
       assert_receive {:broadcast, %{event: "sync/games"}}
+    end
+
+    test "limits based on a timestamp if present" do
+      now = Timex.now()
+
+      user = create_user()
+      game = create_game(user)
+      {:ok, game} = Games.get(game.id)
+
+      Enum.each(1..12, fn i ->
+        Versions.log("update", game, now |> Timex.shift(minutes: -1 * i))
+      end)
+
+      five_minutes_ago = Timex.now() |> Timex.shift(minutes: -5)
+      Backbone.sync_games(five_minutes_ago)
+
+      assert_receive {:broadcast, %{event: "sync/games"}}
+      refute_receive {:broadcast, %{event: "sync/games"}}
     end
   end
 end

--- a/test/socket/backbone_test.exs
+++ b/test/socket/backbone_test.exs
@@ -2,6 +2,7 @@ defmodule Socket.BackboneTest do
   use Gossip.DataCase
 
   alias Gossip.Channels.Channel
+  alias Gossip.Events.Event
   alias Gossip.Games.Game
   alias Socket.Backbone
 
@@ -20,6 +21,42 @@ defmodule Socket.BackboneTest do
       Web.Endpoint.broadcast("channels:newChannel", "channels/broadcast", %{message: "hi"})
 
       assert_receive %{event: "channels/broadcast", payload: %{message: "hi"}}
+    end
+
+    test "broadcasts new events", %{state: state} do
+      message = %Phoenix.Socket.Broadcast{
+        topic: "system:backbone",
+        event: "events/new",
+        payload: %Event{title: "A Holiday"}
+      }
+
+      Backbone.process_event(state, message)
+
+      assert_receive {:broadcast, %{event: "sync/events"}}
+    end
+
+    test "broadcasts edited events", %{state: state} do
+      message = %Phoenix.Socket.Broadcast{
+        topic: "system:backbone",
+        event: "events/edit",
+        payload: %Event{title: "A Holiday"}
+      }
+
+      Backbone.process_event(state, message)
+
+      assert_receive {:broadcast, %{event: "sync/events"}}
+    end
+
+    test "broadcasts deleted events", %{state: state} do
+      message = %Phoenix.Socket.Broadcast{
+        topic: "system:backbone",
+        event: "events/delete",
+        payload: %Event{id: 1, title: "A Holiday"}
+      }
+
+      Backbone.process_event(state, message)
+
+      assert_receive {:broadcast, %{event: "sync/delete"}}
     end
 
     test "broadcasts new games", %{state: state} do

--- a/test/socket/backbone_test.exs
+++ b/test/socket/backbone_test.exs
@@ -165,4 +165,17 @@ defmodule Socket.BackboneTest do
       refute_receive {:broadcast, %{event: "sync/games"}}
     end
   end
+
+  describe "syncing everything" do
+    test "sends game notices over the backbone" do
+      user = create_user()
+      create_game(user)
+      create_channel(%{name: "gossip"})
+
+      Backbone.sync(%{}, %{"event" => "sync", "payload" => %{}})
+
+      assert_receive {:broadcast, %{event: "sync/games"}}
+      assert_receive {:broadcast, %{event: "sync/channels"}}
+    end
+  end
 end


### PR DESCRIPTION
Start adding in game events. Should sync to Grapevine to provide a calendar over there.

- [x] CRUD events
- [x] CRUD sync
- [ ] socket connect sync protocol
- [x] Document the sync protocol

The sync protocol should not send all events like games and channels does on connect. Grapevine/Raisin should get the list of games, detect if the game is newer and then request events since the timestamp it had previously. New events and updates sync as they happen. This new sync protocol is simply for the case that something happens while grapevine is offline (perhaps during a deploy.)

Sync should also keep track of deletes to broadcast on connection.

Example:

- Grapevine has a game from 2018-11-20.
- Grapevine connects and gets that game with information from 2018-11-21.
- Grapevine will request events from 2018-11-20.

```json
{
  "event": "sync/events",
  "payload": {
    "game_id": 1,
    "since": "2018-11-20"
  }
}
```