### PR TITLE
Check a game for MSSP Data

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,6 +4,9 @@ import "./charts"
 import ChatSocket from "./socket";
 window.ChatSocket = ChatSocket;
 
+import MSSPSocket from "./mssp";
+window.MSSPSocket = MSSPSocket;
+
 import React from "react";
 import ReactDOM from "react-dom";
 

--- a/assets/js/mssp.js
+++ b/assets/js/mssp.js
@@ -1,0 +1,54 @@
+import {Socket} from "phoenix"
+
+let guid = () => {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+  }
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+    s4() + '-' + s4() + s4() + s4();
+};
+
+export default class MSSPSocket {
+  constructor(responseSelector) {
+    this.responseSelector = responseSelector;
+    this.responseElement = document.querySelector(responseSelector);
+  }
+
+  connect() {
+    this.socket = new Socket("/chat");
+    this.socket.connect();
+
+    this.channel = this.socket.channel(`mssp:${guid()}`, {});
+    this.channel.join().
+      receive("ok", resp => { console.log("Connected") });
+
+    this.channel.on("mssp/terminated", data => {
+      this.append("Did not find MSSP data");
+    });
+
+    this.channel.on("mssp/received", data => {
+      let json = JSON.stringify(data, null, 2);
+      this.append("Received MSSP:");
+      this.append(json);
+    });
+  }
+
+  checkHost(host, port) {
+    this.reset();
+    this.append(`Checking ${host}:${port}`);
+    this.channel.push("check", {host, port});
+  }
+
+  reset() {
+    this.responseElement.innerHTML = "";
+  }
+
+  append(message) {
+    let fragment = document.createDocumentFragment();
+    let span = document.createElement('span');
+    span.innerHTML = message + "\n";
+    fragment.appendChild(span);
+
+    this.responseElement.appendChild(fragment);
+  }
+}

--- a/lib/gossip/telnet.ex
+++ b/lib/gossip/telnet.ex
@@ -1,0 +1,42 @@
+defmodule Gossip.Telnet do
+  @moduledoc """
+  Telnet context, for finding MSSP data on a MUD
+  """
+
+  alias Gossip.Telnet.MSSPResponse
+  alias Gossip.Repo
+
+  @doc """
+  Record a successful response
+  """
+  def record_mssp_response(host, port, data) do
+    case Repo.get_by(MSSPResponse, host: host, port: port) do
+      nil ->
+        %MSSPResponse{}
+        |> MSSPResponse.success_changeset(host, port, data)
+        |> Repo.insert()
+
+      response ->
+        response
+        |> MSSPResponse.success_changeset(host, port, data)
+        |> Repo.update()
+    end
+  end
+
+  @doc """
+  Record a failed response
+  """
+  def record_no_mssp(host, port) do
+    case Repo.get_by(MSSPResponse, host: host, port: port) do
+      nil ->
+        %MSSPResponse{}
+        |> MSSPResponse.fail_changeset(host, port)
+        |> Repo.insert()
+
+      response ->
+        response
+        |> MSSPResponse.fail_changeset(host, port)
+        |> Repo.update()
+    end
+  end
+end

--- a/lib/gossip/telnet/client.ex
+++ b/lib/gossip/telnet/client.ex
@@ -9,6 +9,7 @@ defmodule Gossip.Telnet.Client do
 
   @do_mssp <<255, 253, 70>>
 
+  alias Gossip.Telnet
   alias Gossip.Telnet.Client.Options
 
   def start_link(opts) do
@@ -47,6 +48,7 @@ defmodule Gossip.Telnet.Client do
       "Terminating connection to #{state.host}:#{state.port} due to no MSSP being sent"
     end, type: :mssp)
     maybe_forward("mssp/terminated", %{}, state)
+    Telnet.record_no_mssp(state.host, state.port)
     {:stop, :normal, state}
   end
 
@@ -62,6 +64,7 @@ defmodule Gossip.Telnet.Client do
         {:mssp, data} = Options.get_mssp_data(options)
         Logger.info("Received MSSP from #{state.host}:#{state.port} - #{inspect(data)}", type: :mssp)
         maybe_forward("mssp/received", data, state)
+        Telnet.record_mssp_response(state.host, state.port, data)
         {:stop, :normal, state}
 
       true ->

--- a/lib/gossip/telnet/client.ex
+++ b/lib/gossip/telnet/client.ex
@@ -1,0 +1,195 @@
+defmodule Gossip.Telnet.Client do
+  @moduledoc """
+  A client to check for MSSP data
+  """
+
+  use GenServer
+
+  alias Gossip.Telnet.Client.Options
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  defp send_term_type() do
+    GenServer.cast(self(), {:send_term_type})
+  end
+
+  defp record_mssp() do
+    GenServer.cast(self(), {:record_mssp})
+  end
+
+  def init(opts) do
+    Process.send_after(self(), {:stop}, 15_000)
+
+    {:ok, %{active: false, host: Keyword.get(opts, :host), port: Keyword.get(opts, :port)}, {:continue, :connect}}
+  end
+
+  def handle_continue(:connect, state) do
+    {:ok, socket} = :gen_tcp.connect(String.to_charlist(state.host), state.port, [:binary, {:packet, 0}])
+    {:noreply, Map.put(state, :socket, socket)}
+  end
+
+  def handle_cast({:record_mssp}, state) do
+    :gen_tcp.send(state.socket, <<255, 253, 70>>)
+    {:noreply, state}
+  end
+
+  def handle_cast({:send_term_type}, state) do
+    :gen_tcp.send(state.socket, <<255, 251, 24>>)
+    :gen_tcp.send(state.socket, <<255, 250, 24, 0>> <> "Mudlet" <> <<255, 240>>)
+    {:noreply, state}
+  end
+
+  def handle_info({:stop}, state) do
+    IO.inspect "terminating due to no mssp data"
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:tcp, _port, data}, state) do
+    IO.inspect data
+    IO.inspect Options.parse(data)
+
+    cond do
+      Options.supports_mssp?(data) ->
+        record_mssp()
+        {:noreply, state}
+
+      Options.mssp_data?(data) ->
+        IO.inspect "got mssp data"
+
+        data
+        |> Options.parse()
+        |> Enum.map(&Options.parse_mssp/1)
+        |> IO.inspect()
+
+        {:stop, :normal, state}
+
+      Options.term_type_request?(data) ->
+        IO.inspect "term type requested"
+        send_term_type()
+
+        {:noreply, state}
+
+      true ->
+        {:noreply, state}
+    end
+  end
+
+  defmodule Options do
+    @moduledoc """
+    Parse telnet IAC options coming from the game
+    """
+
+    def supports_mssp?(binary) do
+      binary
+      |> parse()
+      |> Enum.member?([255, 251, 70])
+    end
+
+    def term_type_request?(binary) do
+      binary
+      |> parse()
+      |> Enum.member?([255, 253, 24])
+    end
+
+    def mssp_data?(binary) do
+      options = parse(binary)
+      Enum.any?(options, fn option ->
+        match?([255, 250, 70 | _], option)
+      end)
+    end
+
+    def parse(binary) do
+      binary
+      |> options([], [])
+      |> Enum.reverse()
+      |> Enum.filter(&(List.first(&1) == 255))
+    end
+
+    def options(<<>>, current, stack) do
+      [Enum.reverse(current) | stack]
+    end
+
+    def options(<<255, 250, data :: binary>>, current, stack) do
+      {sub, data} = parse_sub_negotiation(<<255, 250>> <> data)
+      options(data, [], [sub, Enum.reverse(current) | stack])
+    end
+
+    def options(<<255, 251, byte :: size(8), data :: binary>>, current, stack) do
+      options(data, [], [[255, 251, byte], Enum.reverse(current) | stack])
+    end
+
+    def options(<<255, 253, byte :: size(8), data :: binary>>, current, stack) do
+      options(data, [], [[255, 253, byte], Enum.reverse(current) | stack])
+    end
+
+    def options(<<255, data :: binary>>, current, stack) do
+      options(data, [255], [Enum.reverse(current) | stack])
+    end
+
+    def options(<<byte :: size(8), data :: binary>>, current, stack) do
+      options(data, [byte | current], stack)
+    end
+
+    def parse_sub_negotiation(data) do
+      {stack, data} = sub_option(data, [])
+      {Enum.reverse(stack), data}
+    end
+
+    def sub_option(<<>>, stack), do: {stack, <<>>}
+
+    def sub_option(<<byte :: size(8), 255, 240, data :: binary>>, stack) do
+      {[240, 255, byte | stack], data}
+    end
+
+    def sub_option(<<byte :: size(8), data :: binary>>, stack) do
+      sub_option(data, [byte | stack])
+    end
+
+    @doc """
+    Parse MSSP subnegotiation options
+    """
+    def parse_mssp(data) do
+      data
+      |> mssp(nil, [])
+      |> Enum.reject(&is_nil/1)
+      |> Enum.into(%{}, fn map ->
+        {to_string(Enum.reverse(map[:name])), to_string(Enum.reverse(map[:value]))}
+      end)
+    end
+
+    def mssp([], current, stack) do
+      [current | stack]
+    end
+
+    def mssp([255 | data], current, stack) do
+      mssp(data, current, stack)
+    end
+
+    def mssp([240 | data], current, stack) do
+      mssp(data, current, stack)
+    end
+
+    def mssp([1 | data], current, stack) do
+      mssp(data, %{type: :name, name: [], value: []}, [current | stack])
+    end
+
+    def mssp([2 | data], current, stack) do
+      mssp(data, Map.put(current, :type, :value), stack)
+    end
+
+    def mssp([byte | data], current, stack) do
+      case current[:type] do
+        :name ->
+          mssp(data, Map.put(current, :name, [byte | current.name]), stack)
+
+        :value ->
+          mssp(data, Map.put(current, :value, [byte | current.value]), stack)
+
+        _ ->
+          mssp(data, current, stack)
+      end
+    end
+  end
+end

--- a/lib/gossip/telnet/mssp_response.ex
+++ b/lib/gossip/telnet/mssp_response.ex
@@ -1,0 +1,35 @@
+defmodule Gossip.Telnet.MSSPResponse do
+  @moduledoc """
+  Connection Schema
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  schema "mssp_responses" do
+    field(:host, :string)
+    field(:port, :integer)
+    field(:supports_mssp, :boolean)
+    field(:data, :map)
+
+    timestamps()
+  end
+
+  def success_changeset(struct, host, port, data) do
+    struct
+    |> cast(%{host: host, port: port, data: data}, [:host, :port, :data])
+    |> validate_required([:host, :port, :data])
+    |> put_change(:supports_mssp, true)
+  end
+
+  def fail_changeset(struct, host, port) do
+    struct
+    |> cast(%{host: host, port: port}, [:host, :port])
+    |> validate_required([:host, :port])
+    |> put_change(:data, %{})
+    |> put_change(:supports_mssp, false)
+  end
+end

--- a/lib/web/channels/mssp_channel.ex
+++ b/lib/web/channels/mssp_channel.ex
@@ -1,0 +1,23 @@
+defmodule Web.MSSPChannel do
+  @moduledoc """
+  Follow along with the gossip from the site
+  """
+
+  use Phoenix.Channel
+
+  alias Gossip.Telnet
+
+  def join("mssp:" <> id, _message, socket) do
+    {:ok, assign(socket, :id, id)}
+  end
+
+  def handle_in("check", options, socket) do
+    Telnet.Client.start_link([
+      host: options["host"],
+      port: String.to_integer(options["port"]),
+      channel: socket.assigns.id
+    ])
+
+    {:noreply, socket}
+  end
+end

--- a/lib/web/channels/user_socket.ex
+++ b/lib/web/channels/user_socket.ex
@@ -1,7 +1,8 @@
 defmodule Web.UserSocket do
   use Phoenix.Socket
 
-  channel "channels:*", Web.ChatChannel
+  channel("channels:*", Web.ChatChannel)
+  channel("mssp:*", Web.MSSPChannel)
 
   def connect(_params, socket) do
     {:ok, socket}

--- a/lib/web/controllers/mssp_controller.ex
+++ b/lib/web/controllers/mssp_controller.ex
@@ -1,0 +1,7 @@
+defmodule Web.MSSPController do
+  use Web, :controller
+
+  def index(conn, _params) do
+    render(conn, "index.html")
+  end
+end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -45,6 +45,8 @@ defmodule Web.Router do
 
     get("/media", PageController, :media)
 
+    resources("/mssp", MSSPController, only: [:index])
+
     resources("/redirect-uris", RedirectURIController, only: [:delete])
 
     resources("/register", RegistrationController, only: [:new, :create])

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -79,6 +79,8 @@
         <%= link("Media", to: page_path(@conn, :media)) %>
         |
         <%= link("Code of Conduct", to: page_path(@conn, :conduct)) %>
+        |
+        <%= link("MSSP Check", to: mssp_path(@conn, :index)) %>
         <%= link(to: "https://www.patreon.com/exventure", target: "_blank", class: "mb-4 float-right") do %>
           <%= img_tag("/images/patron.png") %>
         <% end %>

--- a/lib/web/templates/mssp/index.html.eex
+++ b/lib/web/templates/mssp/index.html.eex
@@ -1,0 +1,45 @@
+<section>
+  <nav>
+    <h3 class="name">MSSP Check</h3>
+  </nav>
+
+  <p>If you wish to check what Gossip parses from your game's MSSP data, you can use this checker.</p>
+  <p>Gossip follows the guidelines set on the <%= link("TinTin++ MSSP docs page", to: "https://tintin.sourceforge.io/protocols/mssp/", target: "_blank") %>.</p>
+
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= label(:mssp, :host) %>
+        <%= text_input(:mssp, :host, class: "form-control") %>
+      </div>
+
+      <div class="form-group">
+        <%= label(:mssp, :port) %>
+        <%= number_input(:mssp, :port, class: "form-control") %>
+      </div>
+
+      <button id="start-mssp" class="btn btn-primary">Check!</button>
+    </div>
+
+    <div class="col-md-6">
+      <p>Response:</p>
+      <pre id="mssp-response"></pre>
+    </div>
+  </div>
+</section>
+
+<script>
+document.addEventListener("DOMContentLoaded", function(event) {
+  var socket = new MSSPSocket("#mssp-response");
+  socket.connect();
+
+  document.getElementById("start-mssp").addEventListener("click", function(event) {
+    console.log("clicked");
+
+    var host = document.getElementById("mssp_host");
+    var port = document.getElementById("mssp_port");
+
+    socket.checkHost(host.value, port.value);
+  });
+});
+</script>

--- a/lib/web/templates/mssp/index.html.eex
+++ b/lib/web/templates/mssp/index.html.eex
@@ -33,13 +33,26 @@ document.addEventListener("DOMContentLoaded", function(event) {
   var socket = new MSSPSocket("#mssp-response");
   socket.connect();
 
-  document.getElementById("start-mssp").addEventListener("click", function(event) {
-    console.log("clicked");
+  var host = document.getElementById("mssp_host");
+  var port = document.getElementById("mssp_port");
+  var submit = document.getElementById("start-mssp");
 
-    var host = document.getElementById("mssp_host");
-    var port = document.getElementById("mssp_port");
+  host.addEventListener("keypress", function(event) {
+    if (event.keyCode == 13 || event.which == 13) {
+      submit.dispatchEvent(new Event('click'));
+    }
+  });
 
-    socket.checkHost(host.value, port.value);
+  port.addEventListener("keypress", function(event) {
+    if (event.keyCode == 13 || event.which == 13) {
+      submit.dispatchEvent(new Event('click'));
+    }
+  });
+
+  submit.addEventListener("click", function(event) {
+    if (host.value != "" && port.value != "") {
+      socket.checkHost(host.value, port.value);
+    }
   });
 });
 </script>

--- a/lib/web/views/mssp_view.ex
+++ b/lib/web/views/mssp_view.ex
@@ -1,0 +1,3 @@
+defmodule Web.MSSPView do
+  use Web, :view
+end

--- a/priv/repo/migrations/20181231191750_create_mssp_responses.exs
+++ b/priv/repo/migrations/20181231191750_create_mssp_responses.exs
@@ -1,0 +1,14 @@
+defmodule Gossip.Repo.Migrations.CreateMsspResponses do
+  use Ecto.Migration
+
+  def change do
+    create table(:mssp_responses) do
+      add(:host, :string, null: false)
+      add(:port, :integer, null: false)
+      add(:supports_mssp, :boolean, default: false, null: false)
+      add(:data, :jsonb, null: false)
+
+      timestamps()
+    end
+  end
+end

--- a/test/gossip/telnet/client_test.exs
+++ b/test/gossip/telnet/client_test.exs
@@ -1,0 +1,49 @@
+defmodule Gossip.Telnet.ClientTest do
+  use ExUnit.Case
+
+  alias Gossip.Telnet.Client
+
+  describe "parsing telnet options" do
+    test "a string" do
+      [] = Client.Options.parse("this is a string")
+    end
+
+    test "a single option" do
+      [[255, 251, 86]] = Client.Options.parse(<<255, 251, 86>>)
+    end
+
+    test "multiple options" do
+      [[255, 251, 70], [255, 251, 201], [255, 251, 91]] = Client.Options.parse(<<255, 251, 70, 255, 251, 201, 255, 251, 91>>)
+    end
+
+    test "parsing sub negotitation" do
+      options = <<255, 250, 1, 255, 240, 85>>
+
+      [[255, 250, 1, 255, 240]] = Client.Options.parse(options)
+    end
+
+    test "sub negotiation options" do
+      options =
+        <<255, 250, 1, 78, 65, 77, 69, 2, 69, 120, 86, 101, 110, 116, 117, 114, 101,
+         32, 77, 85, 68, 1, 80, 76, 65, 89, 69, 82, 83, 2, 48, 1, 85, 80, 84, 73, 77,
+         69, 2, 49, 53, 52, 54, 49, 50, 56, 54, 55, 50, 255, 240, 85>>
+
+      {sub, <<85>>} = Client.Options.parse_sub_negotiation(options)
+
+      assert [255, 250 | _] = sub
+    end
+  end
+
+  describe "parsing MSSP variables" do
+    test "pulls out variable names and values" do
+      options =
+        [255, 250, 1, 78, 65, 77, 69, 2, 69, 120, 86, 101, 110, 116, 117, 114, 101,
+         32, 77, 85, 68, 1, 80, 76, 65, 89, 69, 82, 83, 2, 48, 1, 85, 80, 84, 73, 77,
+         69, 2, 49, 53, 52, 54, 49, 50, 56, 54, 55, 50, 255, 240]
+
+      values = Client.Options.parse_mssp(options)
+
+      assert values["NAME"] == "ExVenture MUD"
+    end
+  end
+end

--- a/test/gossip/telnet/client_test.exs
+++ b/test/gossip/telnet/client_test.exs
@@ -37,7 +37,7 @@ defmodule Gossip.Telnet.ClientTest do
   describe "parsing MSSP variables" do
     test "pulls out variable names and values" do
       options =
-        [255, 250, 1, 78, 65, 77, 69, 2, 69, 120, 86, 101, 110, 116, 117, 114, 101,
+        [255, 250, 70, 1, 78, 65, 77, 69, 2, 69, 120, 86, 101, 110, 116, 117, 114, 101,
          32, 77, 85, 68, 1, 80, 76, 65, 89, 69, 82, 83, 2, 48, 1, 85, 80, 84, 73, 77,
          69, 2, 49, 53, 52, 54, 49, 50, 56, 54, 55, 50, 255, 240]
 

--- a/test/gossip/telnet/client_test.exs
+++ b/test/gossip/telnet/client_test.exs
@@ -9,17 +9,17 @@ defmodule Gossip.Telnet.ClientTest do
     end
 
     test "a single option" do
-      [[255, 251, 86]] = Client.Options.parse(<<255, 251, 86>>)
+      [will: :mssp] = Client.Options.parse(<<255, 251, 70>>)
     end
 
     test "multiple options" do
-      [[255, 251, 70], [255, 251, 201], [255, 251, 91]] = Client.Options.parse(<<255, 251, 70, 255, 251, 201, 255, 251, 91>>)
+      [will: :mssp] = Client.Options.parse(<<255, 251, 70, 255, 251, 201, 255, 251, 91>>)
     end
 
     test "parsing sub negotitation" do
-      options = <<255, 250, 1, 255, 240, 85>>
+      options = <<255, 250, 70, 1>> <> "name" <> <<2>> <> "gossip" <> <<255, 240, 85>>
 
-      [[255, 250, 1, 255, 240]] = Client.Options.parse(options)
+      [mssp: %{"name" => "gossip"}] = Client.Options.parse(options)
     end
 
     test "sub negotiation options" do
@@ -37,9 +37,9 @@ defmodule Gossip.Telnet.ClientTest do
   describe "parsing MSSP variables" do
     test "pulls out variable names and values" do
       options =
-        [255, 250, 70, 1, 78, 65, 77, 69, 2, 69, 120, 86, 101, 110, 116, 117, 114, 101,
+        [1, 78, 65, 77, 69, 2, 69, 120, 86, 101, 110, 116, 117, 114, 101,
          32, 77, 85, 68, 1, 80, 76, 65, 89, 69, 82, 83, 2, 48, 1, 85, 80, 84, 73, 77,
-         69, 2, 49, 53, 52, 54, 49, 50, 56, 54, 55, 50, 255, 240]
+         69, 2, 49, 53, 52, 54, 49, 50, 56, 54, 55, 50]
 
       values = Client.Options.parse_mssp(options)
 

--- a/test/gossip/telnet_test.exs
+++ b/test/gossip/telnet_test.exs
@@ -1,0 +1,51 @@
+defmodule Gossip.TelnetTest do
+  use Gossip.DataCase
+
+  alias Gossip.Telnet
+
+  describe "recording a successful response" do
+    test "first time" do
+      {:ok, response} = Telnet.record_mssp_response("example.com", 5555, %{})
+
+      assert response.host == "example.com"
+      assert response.port == 5555
+      assert response.supports_mssp
+      assert response.data == %{}
+    end
+
+    test "updates a previous response" do
+      {:ok, _response} = Telnet.record_mssp_response("example.com", 5555, %{})
+      {:ok, response} = Telnet.record_mssp_response("example.com", 5555, %{"name" => "game"})
+
+      assert response.host == "example.com"
+      assert response.port == 5555
+      assert response.supports_mssp
+      assert response.data == %{"name" => "game"}
+
+      assert length(Repo.all(Telnet.MSSPResponse)) == 1
+    end
+  end
+
+  describe "fail a game" do
+    test "first time" do
+      {:ok, response} = Telnet.record_no_mssp("example.com", 5555)
+
+      assert response.host == "example.com"
+      assert response.port == 5555
+      refute response.supports_mssp
+      assert response.data == %{}
+    end
+
+    test "updates a previous response" do
+      {:ok, _response} = Telnet.record_mssp_response("example.com", 5555, %{})
+      {:ok, response} = Telnet.record_no_mssp("example.com", 5555)
+
+      assert response.host == "example.com"
+      assert response.port == 5555
+      refute response.supports_mssp
+      assert response.data == %{}
+
+      assert length(Repo.all(Telnet.MSSPResponse)) == 1
+    end
+  end
+end


### PR DESCRIPTION
Starts on an MSSP client that will poll games for MSSP data. A lot of games seem to have their own unique incantation to get MSSP data returning, so this might be abandoned. So this starts with a page that lets users check their game for MSSP data and what Gossip sees.